### PR TITLE
Remove extraneous allocations.

### DIFF
--- a/ff3/ff3.go
+++ b/ff3/ff3.go
@@ -215,8 +215,6 @@ func (f Cipher) Encrypt(X string) (string, error) {
 	return ret, nil
 }
 
-var zeros = make([]byte, 16)
-
 // Decrypt decrypts the string X over the current FF3 parameters
 // and returns the plaintext of the same length and format
 func (f Cipher) Decrypt(X string) (string, error) {
@@ -284,7 +282,7 @@ func (f Cipher) Decrypt(X string) (string, error) {
 		}
 
 		numABytes := numA.Bytes()
-		P.Write(zeros[0 : 12-len(numABytes)])
+		P.Write(ivZero[0 : 12-len(numABytes)])
 		P.Write(numABytes)
 
 		// Calculate S

--- a/ff3/ff3.go
+++ b/ff3/ff3.go
@@ -215,6 +215,8 @@ func (f Cipher) Encrypt(X string) (string, error) {
 	return ret, nil
 }
 
+var zeros = make([]byte, 16)
+
 // Decrypt decrypts the string X over the current FF3 parameters
 // and returns the plaintext of the same length and format
 func (f Cipher) Decrypt(X string) (string, error) {
@@ -246,8 +248,16 @@ func (f Cipher) Decrypt(X string) (string, error) {
 	Tl := f.tweak[:4]
 	Tr := f.tweak[4:]
 
+	// cache for c
+	var (
+		P            bytes.Buffer
+		bmod, numA   big.Int
+		br, bm, y, c big.Int
+	)
+
 	// Main Feistel Round, 8 times
 	for i := numRounds - 1; i >= 0; i-- {
+		P.Reset()
 		var m uint32
 		var W []byte
 
@@ -266,45 +276,38 @@ func (f Cipher) Decrypt(X string) (string, error) {
 		if err != nil {
 			return ret, err
 		}
-		P := bytes.NewBuffer(xored)
+		P.Write(xored)
 
-		var numA *big.Int
-		numA, err = numRadix(rev(A), f.radix)
-		if err != nil {
-			return ret, err
+		_, ok := numA.SetString(rev(A), f.radix)
+		if !ok {
+			return ret, errors.New("numRadix failed")
 		}
 
 		numABytes := numA.Bytes()
+		P.Write(zeros[0 : 12-len(numABytes)])
+		P.Write(numABytes)
 
-		_, err = P.Write(append(make([]byte, 12-len(numABytes)), numABytes...))
-		if err != nil {
-			return ret, err
-		}
-
-		// Calculate S
 		// Calculate S
 		S, err := f.ciph(revB(P.Bytes()))
 		if err != nil {
 			return ret, err
 		}
-
 		copy(S[:], revB(S[:]))
 
 		// Calculate y
-		y := big.NewInt(0)
 		y.SetBytes(S[:])
 
 		// Calculate c
-		mod := big.NewInt(0)
-		mod.Exp(big.NewInt(int64(f.radix)), big.NewInt(int64(m)), nil)
+		br.SetInt64(int64(f.radix))
+		bm.SetInt64(int64(m))
+		bmod.Exp(&br, &bm, nil)
 
-		c, err := numRadix(rev(B), f.radix)
-		if err != nil {
-			return ret, err
+		_, ok = c.SetString(rev(B), f.radix)
+		if !ok {
+			return ret, errors.New("numRadix failed")
 		}
-
-		c.Sub(c, y)
-		c.Mod(c, mod)
+		c.Sub(&c, &y)
+		c.Mod(&c, &bmod)
 
 		// Need to pad the text with leading 0s first to make sure it's the correct length
 		C := c.Text(f.radix)
@@ -327,14 +330,11 @@ func (f *Cipher) ciph(input []byte) ([]byte, error) {
 	if len(input)%aes.BlockSize != 0 {
 		return nil, errors.New("Length of ciph input must be multiple of 16")
 	}
-
-	ciphertext := make([]byte, len(input))
-	f.cbcEncryptor.CryptBlocks(ciphertext, input)
+	f.cbcEncryptor.CryptBlocks(input, input)
 
 	// Reset IV to 0
 	f.cbcEncryptor.(cbcMode).SetIV(ivZero[:])
-
-	return ciphertext, nil
+	return input, nil
 }
 
 // numRadix interprets a string of digits as a number. Same as ParseUint but using math/big library
@@ -354,34 +354,26 @@ func xorBytes(a, b []byte) ([]byte, error) {
 	if len(a) != len(b) {
 		return nil, errors.New("inputs to xorBytes must be of same length")
 	}
-	ret := make([]byte, len(a))
-
 	for i := 0; i < len(a); i++ {
-		ret[i] = a[i] ^ b[i]
+		b[i] = a[i] ^ b[i]
 	}
-
-	return ret, nil
+	return b, nil
 }
 
 // Returns the reversed version of an arbitrary string
 func rev(s string) string {
 	r := []rune(s)
-
 	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
 		r[i], r[j] = r[j], r[i]
 	}
-
 	return string(r)
 }
 
 // Returns the reversed version of a byte array
-func revB(in []byte) []byte {
-	out := make([]byte, len(in))
-
-	for i := len(in)/2 - 1; i >= 0; i-- {
-		opp := len(in) - 1 - i
-		out[i], out[opp] = in[opp], in[i]
+func revB(a []byte) []byte {
+	for i := len(a)/2 - 1; i >= 0; i-- {
+		opp := len(a) - 1 - i
+		a[i], a[opp] = a[opp], a[i]
 	}
-
-	return out
+	return a
 }


### PR DESCRIPTION
## What's in this PR?

I removed extraneous allocations to illustrate the techniques for use in other areas of the library if the author would like.

## TODOs

I saw the CLA after I made the changes, my mistake. I'll look into it tomorrow evening maybe, depending how much information I need to disclose.

> benchmark                          old ns/op     new ns/op     delta
> BenchmarkDecrypt/Sample_#1-24      45900         30815         -32.86%
> BenchmarkDecrypt/Sample_#2-24      45662         31572         -30.86%
> BenchmarkDecrypt/Sample_#3-24      49453         39011         -21.11%
> BenchmarkDecrypt/Sample_#4-24      44523         37762         -15.19%
> BenchmarkDecrypt/Sample_#5-24      40971         25624         -37.46%
> BenchmarkDecrypt/Sample_#6-24      45525         27824         -38.88%
> BenchmarkDecrypt/Sample_#7-24      42651         30249         -29.08%
> BenchmarkDecrypt/Sample_#8-24      49264         39506         -19.81%
> BenchmarkDecrypt/Sample_#9-24      42568         31181         -26.75%
> BenchmarkDecrypt/Sample_#10-24     42259         25162         -40.46%
> BenchmarkDecrypt/Sample_#11-24     46210         32699         -29.24%
> BenchmarkDecrypt/Sample_#12-24     39739         29340         -26.17%
> BenchmarkDecrypt/Sample_#13-24     50127         34662         -30.85%
> BenchmarkDecrypt/Sample_#14-24     52410         37990         -27.51%
> BenchmarkDecrypt/Sample_#15-24     44501         30777         -30.84%
> 
> benchmark                          old allocs     new allocs     delta
> BenchmarkDecrypt/Sample_#1-24      231            102            -55.84%
> BenchmarkDecrypt/Sample_#2-24      237            108            -54.43%
> BenchmarkDecrypt/Sample_#3-24      234            105            -55.13%
> BenchmarkDecrypt/Sample_#4-24      234            105            -55.13%
> BenchmarkDecrypt/Sample_#5-24      228            99             -56.58%
> BenchmarkDecrypt/Sample_#6-24      237            108            -54.43%
> BenchmarkDecrypt/Sample_#7-24      231            102            -55.84%
> BenchmarkDecrypt/Sample_#8-24      234            105            -55.13%
> BenchmarkDecrypt/Sample_#9-24      234            105            -55.13%
> BenchmarkDecrypt/Sample_#10-24     228            99             -56.58%
> BenchmarkDecrypt/Sample_#11-24     231            102            -55.84%
> BenchmarkDecrypt/Sample_#12-24     234            105            -55.13%
> BenchmarkDecrypt/Sample_#13-24     237            108            -54.43%
> BenchmarkDecrypt/Sample_#14-24     237            108            -54.43%
> BenchmarkDecrypt/Sample_#15-24     228            99             -56.58%
> 
> benchmark                          old bytes     new bytes     delta
> BenchmarkDecrypt/Sample_#1-24      7728          2912          -62.32%
> BenchmarkDecrypt/Sample_#2-24      7728          2928          -62.11%
> BenchmarkDecrypt/Sample_#3-24      8176          3344          -59.10%
> BenchmarkDecrypt/Sample_#4-24      8176          3344          -59.10%
> BenchmarkDecrypt/Sample_#5-24      7696          2912          -62.16%
> BenchmarkDecrypt/Sample_#6-24      7760          2928          -62.27%
> BenchmarkDecrypt/Sample_#7-24      7728          2912          -62.32%
> BenchmarkDecrypt/Sample_#8-24      8176          3344          -59.10%
> BenchmarkDecrypt/Sample_#9-24      8176          3344          -59.10%
> BenchmarkDecrypt/Sample_#10-24     7696          2912          -62.16%
> BenchmarkDecrypt/Sample_#11-24     7728          2912          -62.32%
> BenchmarkDecrypt/Sample_#12-24     7744          2928          -62.19%
> BenchmarkDecrypt/Sample_#13-24     8192          3360          -58.98%
> BenchmarkDecrypt/Sample_#14-24     8192          3360          -58.98%
> BenchmarkDecrypt/Sample_#15-24     7696          2912          -62.16%
> 