### PR TITLE
ff1/ff3 - add optional WithTweak functions, fixes #7

### DIFF
--- a/ff1/ff1.go
+++ b/ff1/ff1.go
@@ -45,6 +45,9 @@ var (
 
 	// ErrStringNotInRadix is returned if input or intermediate strings cannot be parsed in the given radix
 	ErrStringNotInRadix = errors.New("string is not within base/radix")
+
+	// ErrTweakLengthInvalid is returned if the tweak length is not in the given range
+	ErrTweakLengthInvalid = errors.New("tweak must be between 0 and given maxTLen, inclusive")
 )
 
 // Need this for the SetIV function which CBCEncryptor has, but cipher.BlockMode interface doesn't.
@@ -86,7 +89,7 @@ func NewCipher(radix int, maxTLen int, key []byte, tweak []byte) (Cipher, error)
 
 	// Make sure the length of given tweak is in range
 	if len(tweak) > maxTLen {
-		return newCipher, errors.New("tweak must be between 0 and given maxTLen, inclusive")
+		return newCipher, ErrTweakLengthInvalid
 	}
 
 	// Calculate minLength
@@ -143,7 +146,7 @@ func (c Cipher) EncryptWithTweak(X string, tweak []byte) (string, error) {
 
 	// Make sure the length of given tweak is in range
 	if len(tweak) > c.maxTLen {
-		return ret, errors.New("tweak must be between 0 and given maxTLen, inclusive")
+		return ret, ErrTweakLengthInvalid
 	}
 
 	radix := c.radix
@@ -382,7 +385,7 @@ func (c Cipher) DecryptWithTweak(X string, tweak []byte) (string, error) {
 
 	// Make sure the length of given tweak is in range
 	if len(tweak) > c.maxTLen {
-		return ret, errors.New("tweak must be between 0 and given maxTLen, inclusive")
+		return ret, ErrTweakLengthInvalid
 	}
 
 	radix := c.radix

--- a/ff1/ff1.go
+++ b/ff1/ff1.go
@@ -56,10 +56,11 @@ type cbcMode interface {
 // A Cipher is an instance of the FF1 mode of format preserving encryption
 // using a particular key, radix, and tweak
 type Cipher struct {
-	tweak  []byte
-	radix  int
-	minLen uint32
-	maxLen uint32
+	tweak   []byte
+	radix   int
+	minLen  uint32
+	maxLen  uint32
+	maxTLen int
 
 	// Re-usable CBC encryptor with exported SetIV function
 	cbcEncryptor cipher.BlockMode
@@ -83,9 +84,9 @@ func NewCipher(radix int, maxTLen int, key []byte, tweak []byte) (Cipher, error)
 		return newCipher, errors.New("radix must be between 2 and 36, inclusive")
 	}
 
-	// Make sure the given the length of tweak is in range
-	if (len(tweak) < 0) || (len(tweak) > maxTLen) {
-		return newCipher, errors.New("tweak must be between 0 and maxTLen, inclusive")
+	// Make sure the length of given tweak is in range
+	if len(tweak) > maxTLen {
+		return newCipher, errors.New("tweak must be between 0 and given maxTLen, inclusive")
 	}
 
 	// Calculate minLength
@@ -110,6 +111,7 @@ func NewCipher(radix int, maxTLen int, key []byte, tweak []byte) (Cipher, error)
 	newCipher.radix = radix
 	newCipher.minLen = minLen
 	newCipher.maxLen = maxLen
+	newCipher.maxTLen = maxTLen
 	newCipher.cbcEncryptor = cbcEncryptor
 
 	return newCipher, nil
@@ -118,16 +120,27 @@ func NewCipher(radix int, maxTLen int, key []byte, tweak []byte) (Cipher, error)
 // Encrypt encrypts the string X over the current FF1 parameters
 // and returns the ciphertext of the same length and format
 func (c Cipher) Encrypt(X string) (string, error) {
+	return c.EncryptWithTweak(X, c.tweak)
+}
+
+// EncryptWithTweak is the same as Encrypt except it uses the
+// tweak from the parameter rather than the current Cipher's tweak
+func (c Cipher) EncryptWithTweak(X string, tweak []byte) (string, error) {
 	var ret string
 	var err error
 	var ok bool
 
 	n := uint32(len(X))
-	t := len(c.tweak)
+	t := len(tweak)
 
 	// Check if message length is within minLength and maxLength bounds
 	if (n < c.minLen) || (n > c.maxLen) {
 		return ret, errors.New("message length is not within min and max bounds")
+	}
+
+	// Make sure the length of given tweak is in range
+	if len(tweak) > c.maxTLen {
+		return ret, errors.New("tweak must be between 0 and given maxTLen, inclusive")
 	}
 
 	radix := c.radix
@@ -205,7 +218,7 @@ func (c Cipher) Encrypt(X string) (string, error) {
 	Q := buf[:lenQ]
 	// This is the fixed part of Q
 	// First t bytes of Q are the tweak, next numPad bytes are already zero-valued
-	copy(Q[:t], c.tweak)
+	copy(Q[:t], tweak)
 
 	// Use PQ as a combined storage for P||Q
 	// PQ will use the next 16+lenQ bytes of buf
@@ -343,16 +356,27 @@ func (c Cipher) Encrypt(X string) (string, error) {
 // Decrypt decrypts the string X over the current FF1 parameters
 // and returns the plaintext of the same length and format
 func (c Cipher) Decrypt(X string) (string, error) {
+	return c.DecryptWithTweak(X, c.tweak)
+}
+
+// DecryptWithTweak is the same as Decrypt except it uses the
+// tweak from the parameter rather than the current Cipher's tweak
+func (c Cipher) DecryptWithTweak(X string, tweak []byte) (string, error) {
 	var ret string
 	var err error
 	var ok bool
 
 	n := uint32(len(X))
-	t := len(c.tweak)
+	t := len(tweak)
 
 	// Check if message length is within minLength and maxLength bounds
 	if (n < c.minLen) || (n > c.maxLen) {
 		return ret, errors.New("message length is not within min and max bounds")
+	}
+
+	// Make sure the length of given tweak is in range
+	if len(tweak) > c.maxTLen {
+		return ret, errors.New("tweak must be between 0 and given maxTLen, inclusive")
 	}
 
 	radix := c.radix
@@ -430,7 +454,7 @@ func (c Cipher) Decrypt(X string) (string, error) {
 	Q := buf[:lenQ]
 	// This is the fixed part of Q
 	// First t bytes of Q are the tweak, next numPad bytes are already zero-valued
-	copy(Q[:t], c.tweak)
+	copy(Q[:t], tweak)
 
 	// Use PQ as a combined storage for P||Q
 	// PQ will use the next 16+lenQ bytes of buf

--- a/ff1/ff1.go
+++ b/ff1/ff1.go
@@ -125,6 +125,9 @@ func (c Cipher) Encrypt(X string) (string, error) {
 
 // EncryptWithTweak is the same as Encrypt except it uses the
 // tweak from the parameter rather than the current Cipher's tweak
+// This allows you to re-use a single Cipher (for a given key) and simply
+// override the tweak for each unique data input, which is a practical
+// use-case of FPE for things like credit card numbers.
 func (c Cipher) EncryptWithTweak(X string, tweak []byte) (string, error) {
 	var ret string
 	var err error
@@ -361,6 +364,9 @@ func (c Cipher) Decrypt(X string) (string, error) {
 
 // DecryptWithTweak is the same as Decrypt except it uses the
 // tweak from the parameter rather than the current Cipher's tweak
+// This allows you to re-use a single Cipher (for a given key) and simply
+// override the tweak for each unique data input, which is a practical
+// use-case of FPE for things like credit card numbers.
 func (c Cipher) DecryptWithTweak(X string, tweak []byte) (string, error) {
 	var ret string
 	var err error

--- a/ff3/ff3.go
+++ b/ff3/ff3.go
@@ -45,6 +45,9 @@ var (
 
 	// ErrStringNotInRadix is returned if input or intermediate strings cannot be parsed in the given radix
 	ErrStringNotInRadix = errors.New("string is not within base/radix")
+
+	// ErrTweakLengthInvalid is returned if the tweak length is not 8 bytes
+	ErrTweakLengthInvalid = errors.New("tweak must be 8 bytes, or 64 bits")
 )
 
 // A Cipher is an instance of the FF3 mode of format preserving encryption
@@ -78,7 +81,7 @@ func NewCipher(radix int, key []byte, tweak []byte) (Cipher, error) {
 
 	// Make sure the given the length of tweak in bits is 64
 	if len(tweak) != tweakLen {
-		return newCipher, errors.New("tweak must be 8 bytes, or 64 bits")
+		return newCipher, ErrTweakLengthInvalid
 	}
 
 	// Calculate minLength - according to the spec, radix^minLength >= 100.
@@ -110,6 +113,15 @@ func NewCipher(radix int, key []byte, tweak []byte) (Cipher, error) {
 // Encrypt encrypts the string X over the current FF3 parameters
 // and returns the ciphertext of the same length and format
 func (c Cipher) Encrypt(X string) (string, error) {
+	return c.EncryptWithTweak(X, c.tweak)
+}
+
+// EncryptWithTweak is the same as Encrypt except it uses the
+// tweak from the parameter rather than the current Cipher's tweak
+// This allows you to re-use a single Cipher (for a given key) and simply
+// override the tweak for each unique data input, which is a practical
+// use-case of FPE for things like credit card numbers.
+func (c Cipher) EncryptWithTweak(X string, tweak []byte) (string, error) {
 	var ret string
 	var ok bool
 
@@ -120,6 +132,11 @@ func (c Cipher) Encrypt(X string) (string, error) {
 	// the input check to >= instead of only >
 	if (n < c.minLen) || (n >= c.maxLen) {
 		return ret, errors.New("message length is not within min and max bounds")
+	}
+
+	// Make sure the given the length of tweak in bits is 64
+	if len(tweak) != tweakLen {
+		return ret, ErrTweakLengthInvalid
 	}
 
 	radix := c.radix
@@ -140,8 +157,8 @@ func (c Cipher) Encrypt(X string) (string, error) {
 	B := X[u:]
 
 	// Split the tweak
-	Tl := c.tweak[:halfTweakLen]
-	Tr := c.tweak[halfTweakLen:]
+	Tl := tweak[:halfTweakLen]
+	Tr := tweak[halfTweakLen:]
 
 	// P is always 16 bytes
 	var (
@@ -245,6 +262,15 @@ func (c Cipher) Encrypt(X string) (string, error) {
 // Decrypt decrypts the string X over the current FF3 parameters
 // and returns the plaintext of the same length and format
 func (c Cipher) Decrypt(X string) (string, error) {
+	return c.DecryptWithTweak(X, c.tweak)
+}
+
+// DecryptWithTweak is the same as Decrypt except it uses the
+// tweak from the parameter rather than the current Cipher's tweak
+// This allows you to re-use a single Cipher (for a given key) and simply
+// override the tweak for each unique data input, which is a practical
+// use-case of FPE for things like credit card numbers.
+func (c Cipher) DecryptWithTweak(X string, tweak []byte) (string, error) {
 	var ret string
 	var ok bool
 
@@ -255,6 +281,11 @@ func (c Cipher) Decrypt(X string) (string, error) {
 	// the input check to >= instead of only >
 	if (n < c.minLen) || (n >= c.maxLen) {
 		return ret, errors.New("message length is not within min and max bounds")
+	}
+
+	// Make sure the given the length of tweak in bits is 64
+	if len(tweak) != tweakLen {
+		return ret, ErrTweakLengthInvalid
 	}
 
 	radix := c.radix
@@ -275,8 +306,8 @@ func (c Cipher) Decrypt(X string) (string, error) {
 	B := X[u:]
 
 	// Split the tweak
-	Tl := c.tweak[:halfTweakLen]
-	Tr := c.tweak[halfTweakLen:]
+	Tl := tweak[:halfTweakLen]
+	Tr := tweak[halfTweakLen:]
 
 	// P is always 16 bytes
 	var (

--- a/ff3/ff3.go
+++ b/ff3/ff3.go
@@ -40,9 +40,6 @@ const (
 )
 
 var (
-	// For all AES-CBC calls, IV is always 0
-	ivZero = make([]byte, blockSize)
-
 	// ErrStringNotInRadix is returned if input or intermediate strings cannot be parsed in the given radix
 	ErrStringNotInRadix = errors.New("string is not within base/radix")
 


### PR DESCRIPTION
## What's in this PR?

This PR adds 2 functions to both `ff1` and `ff3` packages: `EncryptWithTweak` and `DecryptWithTweak` which have the same behavior as the existing `Encrypt` and `Decrypt` functions except they take an extra parameter `tweak` which overrides the use of the current `Cipher`'s `tweak`. This fixes #7, and should aid in common FPE scenarios like encrypting/tokenizing credit card numbers without having to create new `Cipher`s for each number/operation.

The existing `Encrypt` and `Decrypt` functions remain as is, so this API addition/change is non-breaking. Now, `Encrypt` just calls `EncryptWithTweak(c.tweak)` for code re-use.

There was no change in benchmarks either. 
