### PR TITLE
FF1 to support crypto engine who does padding

### DIFF
--- a/ff1/ff1.go
+++ b/ff1/ff1.go
@@ -599,7 +599,11 @@ func (c Cipher) ciph(input []byte) ([]byte, error) {
 		return nil, errors.New("length of ciph input must be multiple of 16")
 	}
 
-	c.cbcEncryptor.CryptBlocks(input, input)
+	// Some crypto engines (e.g. PKCS7) always do padding (i.e. additional block is added), we need output buffer one block bigger
+	ciphertext := make([]byte, len(input)+blockSize)
+	c.cbcEncryptor.CryptBlocks(ciphertext, input)
+	// This FF1 implementation is update buffer in-place, copy result back to input
+	copy(input, ciphertext[:len(input)])
 
 	// Reset IV to 0
 	c.cbcEncryptor.(cbcMode).SetIV(ivZero)


### PR DESCRIPTION
Some crypto engines (e.g. PKCS7) always do padding (i.e. even input is aligned with block size, additional block is added to output of encryption). Make changes to support these engines

## What's in this PR?

For FF1 to support crypto engine who does padding